### PR TITLE
Addition of basic reset token functionality 

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "express-jwt": "^5.3.1",
     "express-jwt-authz": "^2.3.1",
     "jsonwebtoken": "^8.5.1",
-    "level": "^6.0.0"
+    "level": "^6.0.0",
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
     "nodemon": "^1.19.4"

--- a/src/facades/refreshToken.js
+++ b/src/facades/refreshToken.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const { getById, db } = require('../lib/db')
+const uuid = require('uuid/v4')
+
+const REFESH_TOKEN_KEY_PREFIX = 'refreshTokenByUserId'
+
+/**
+ * Will return a refreshToken by email.
+ * Accepts one url param: email
+ * Matching is case sensitive and uses a startswith comparison
+ * @param params
+ */
+exports.getRefreshToken = async (userId) => {
+  return await getById(REFESH_TOKEN_KEY_PREFIX, userId)
+}
+
+exports.putRefreshToken = (userId) => {
+  const token = uuid()
+  const refresh_token = { userId, token }
+  db.put(`${REFESH_TOKEN_KEY_PREFIX}\x00${userId}`, refresh_token)
+  return token
+}

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -82,7 +82,7 @@ const _generateAuthorizationForUser = async (user, includeToken = false) => {
 
   if (includeToken) {
     const token = putRefreshToken(user.id)
-    auth['refreshToken'] = token
+    auth['refresh_token'] = token
   }
   
   return auth

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -4,6 +4,7 @@ const bcrypt = require('bcrypt')
 const jwt = require('jsonwebtoken')
 const router = require('express').Router()
 const { getUserByEmail } = require('../facades/user')
+const { getRefreshToken, putRefreshToken } = require('../facades/refreshToken')
 
 router.post('/', async (req, res) => {
   const { email, password } = req.body
@@ -24,19 +25,67 @@ router.post('/', async (req, res) => {
       res.sendStatus(401)
       return
     }
-    const { id, name, scope } = user
-    const accessToken = jwt.sign({
-      id,
-      email,
-      name,
-      scope
-    }, 'SOMESECRET', { expiresIn: 3000 })
-    res.json({
-      'access_token': accessToken
-    })
+
+    res.json(await _generateAuthorizationForUser(user, true))
   } catch (e) {
+    console.log(e)
     res.sendStatus(500)
   }
 })
+
+router.post('/token', async (req, res) => {
+  const { email } = req.body
+  const refreshToken = req.body.refresh_token
+  if (!email || !refreshToken) {
+    res.status(400).json({
+      message: 'Provide email & token'
+    })
+    return
+  }
+  try {
+    const user = await getUserByEmail(email)
+    if (!user) {
+      res.sendStatus(401)
+      return
+    }
+    const storedToken = await getRefreshToken(user.id)
+    if (!storedToken) {
+      res.sendStatus(401)
+      return
+    }
+    if (storedToken.token !== refreshToken) {
+      res.sendStatus(401)
+      return
+    }
+    res.json(await _generateAuthorizationForUser(user))
+  } catch (e) {
+    console.log(e)
+    res.sendStatus(500)
+  }
+})
+
+const _generateTokenForUser = (user) => {
+  const { id, name, email, scope } = user
+  return jwt.sign({
+    id,
+    email,
+    name,
+    scope
+  }, 'SOMESECRET', { expiresIn: 3000 })
+}
+
+const _generateAuthorizationForUser = async (user, includeToken = false) => {
+  const accessToken = _generateTokenForUser(user)
+  const auth = {
+    'access_token': accessToken
+  }
+
+  if (includeToken) {
+    const token = putRefreshToken(user.id)
+    auth['refreshToken'] = token
+  }
+  
+  return auth
+}
 
 module.exports = router


### PR DESCRIPTION
# What is this PR For?
I have added some basic reset token functionality.
* Modified the /auth route to return both the access_token and refresh_token. As well as store the userId and refresh_token into the database, so it can be verified.
* Added a new /token route which when given a username and the matching refresh token, will return a new access_token

Note: The refresh token is sent as plain text to the user. Also there is no expiry time, nor is there any functionality to remove existing active refresh tokens. However that functionality could be added at a later time.

## What is required to test this functionality?
* You must run an npm install, or an install of whatever your preferred package manager is

## How was this tested?
* Authenticate with a user to the /auth route. Take the given refresh_token. Use the /auth/token route to pass the email and refresh_token in the body of the request. Verify that you can use the given access_token to authenticate to the DELETE /books/<book-id> endpoint.
* Authenticate with a user to the /auth route. Take the given refresh_token. Use the /auth/token route to pass the refresh_token and a different email in the body of the request. Verify that you receive a 401 unauthorized.
* Authenticate with a user to the /auth route. Take the given refresh_token. Use the /auth/token route to pass the email and a different value for the refresh_token in the body of the request. Verify that you receive a 401 unauthorized.